### PR TITLE
Remove duplicate shebang in SSL module

### DIFF
--- a/install-smtp/modules/06_ssl.sh
+++ b/install-smtp/modules/06_ssl.sh
@@ -5,9 +5,7 @@ MOD_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 . "${MOD_DIR}/../lib/common.sh"
 : "${VARS_FILE:?}"
 
-#!/usr/bin/env bash
 # Module: SSL/Certbot + TLS для Postfix/Dovecot (функции + entrypoint)
-set -euo pipefail
 
 # используем общий логгер/раннер
 


### PR DESCRIPTION
## Summary
- remove redundant shebang and `set -euo pipefail` from SSL configuration script

## Testing
- `bash -n install-smtp/modules/06_ssl.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5227bf360832f98856ac06a390103