### PR TITLE
feat: use 2048-bit DKIM keys by default

### DIFF
--- a/install-smtp/vars.yaml.example
+++ b/install-smtp/vars.yaml.example
@@ -20,6 +20,7 @@ acme_email: noc@example.com
 
 # DKIM
 dkim_selector: s1               # селектор для 05_dkim.sh
+dkim_key_bits: 2048            # размер ключа DKIM (1024 для совместимости с устаревшими DNS)
 
 # Beget API для 09_beget_dns.sh
 beget:


### PR DESCRIPTION
## Summary
- default DKIM keys to 2048 bits with configurable fallback
- allow setting key length via `dkim_key_bits` in vars
- sync OpenDKIM MinimumKeyBits with selected key length

## Testing
- `bash -n install-smtp/modules/05_dkim.sh`
- `shellcheck install-smtp/modules/05_dkim.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c523e90eb8832fadd5f067fd0fb3c6